### PR TITLE
Allow parsing of quests if QuestText is not in json

### DIFF
--- a/RiseQuestLoader/QuestLoader.cpp
+++ b/RiseQuestLoader/QuestLoader.cpp
@@ -842,7 +842,6 @@ REString* QuestLoader::get_quest_text_hook(void* vmctx, ManagedObject* this_, Qu
         const auto& quest = loader->m_custom_quests[quest_id];
 
         if (!quest.m_is_replacement || !quest.m_use_default) {
-            API::get()->log_error("%i", quest.m_quest_id);
             const auto language = loader->m_resource_manager->get_language();
             const auto& info = quest.get_quest_info(language);
 

--- a/RiseQuestLoader/QuestLoader.cpp
+++ b/RiseQuestLoader/QuestLoader.cpp
@@ -835,7 +835,7 @@ REString* QuestLoader::get_quest_text_hook(void* vmctx, ManagedObject* this_, Qu
     if (loader->m_custom_quests.contains(quest_id)) {
         const auto& quest = loader->m_custom_quests[quest_id];
 
-        if (!quest.m_is_replacement || quest.m_enabled) {
+        if (!quest.m_is_replacement || !quest.m_use_default) {
             const auto language = loader->m_resource_manager->get_language();
             const auto& info = quest.get_quest_info(language);
 

--- a/RiseQuestLoader/QuestLoader.h
+++ b/RiseQuestLoader/QuestLoader.h
@@ -90,7 +90,7 @@ public:
             }
 
             m_quest_id = j.value("QuestID", 0);
-            if (j.contains("QuestText")) {
+            if (j.contains("QuestText") && j["QuestText"].type() != nlohmann::detail::value_t::null) {
                 m_fallback_language = language::get_language(j["QuestText"]["FallbackLanguage"]);
 
                 for (const auto& info : j["QuestText"]["QuestInfo"]) {

--- a/RiseQuestLoader/QuestLoader.h
+++ b/RiseQuestLoader/QuestLoader.h
@@ -36,6 +36,7 @@ public:
         reframework::API::ManagedObject* m_original_object{};
         bool m_is_replacement{false};
         bool m_enabled{true};
+        bool m_use_default{false};
 
         void enable(reframework::API::ManagedObject* questdict) {
             if (m_is_replacement) {
@@ -89,16 +90,17 @@ public:
             }
 
             m_quest_id = j.value("QuestID", 0);
-            m_fallback_language = language::get_language(j["QuestText"]["FallbackLanguage"]);
+            if (j.contains("QuestText")) {
+                m_fallback_language = language::get_language(j["QuestText"]["FallbackLanguage"]);
 
-            for (const auto& info : j["QuestText"]["QuestInfo"]) {
-                m_quest_infos[language::get_language(info["Language"])] = {
-                    info["Name"],
-                    info["Client"],
-                    info["Description"],
-                    info["Target"],
-                    info.value("Fail", "")
-                };
+                for (const auto& info : j["QuestText"]["QuestInfo"]) {
+                    m_quest_infos[language::get_language(info["Language"])] = {
+                        info["Name"], info["Client"], info["Description"], info["Target"], info.value("Fail", "")};
+                }
+            } else {
+                if (m_is_replacement)
+                    m_use_default = true;
+                m_quest_infos[m_fallback_language] = {"", "", "", "", ""};
             }
         }
         ~CustomQuest() {

--- a/RiseQuestLoader/RiseQuestLoader.vcxproj
+++ b/RiseQuestLoader/RiseQuestLoader.vcxproj
@@ -24,6 +24,10 @@
     <ProjectGuid>{7c38e2ca-a0bb-4e31-a73b-ba65808ac609}</ProjectGuid>
     <RootNamespace>RiseQuestLoader</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <GameRegistryPath>HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 1446780</GameRegistryPath>
+    <GamePath Condition="'$(GamePath)' == ''">$([MSBuild]::GetRegistryValueFromView('$(GameRegistryPath)', 'InstallLocation', null, RegistryView.Registry32))</GamePath>
+    <GamePath Condition="'$(GamePath)' == ''">$([MSBuild]::GetRegistryValueFromView('$(GameRegistryPath)', 'InstallLocation', null, RegistryView.Registry64))</GamePath>
+    <GamePath Condition="'$(GamePath)' == ''">$(targetdir)</GamePath>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -144,7 +148,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>copy $(targetdir)$(targetname).dll "E:\SteamLibrary\steamapps\common\MonsterHunterRise\reframework\plugins\"</Command>
+      <Command>copy $(targetdir)$(targetname).dll "$(GamePath)\reframework\plugins\"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
- For replacement quests, the quest will fallback to the default in-game text for the quest
- For custom quests, the quest will display empty strings for all relevant text
- Changed the output copy directory to be automated using registry path
- Fixed incorrect error logging format